### PR TITLE
Issue #9 - upgrade to MusicPlayer 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ extension manager dialog, pick "Scenery" from the "Installed" tab, and hit the "
 
 ### Option 2: manual download and install
 
-You can download the extension manually: [ext-mp-scenery-3.1.0](http://www.corbett.ca/apps/MusicPlayer/extensions/3.1/ext-mp-scenery-3.1.0.jar)
+You can download the extension manually: [ext-mp-scenery-4.0.0](http://www.corbett.ca/apps/MusicPlayer/extensions/4.0/ext-mp-scenery-4.0.0.jar)
 
 Save the jar to your ~/.MusicPlayer/extensions directory and restart the application.
 
@@ -110,15 +110,15 @@ You can clone this repo and build the extension jar with maven (Java 17 or highe
 ```shell
 https://github.com/scorbo2/ext-mp-scenery.git
 cd ext-mp-scenery
-mvn package # NOTE! You must have MusicPlayer-3.1 in your local maven repository for this to work!
+mvn package # NOTE! You must have MusicPlayer-4.0 in your local maven repository for this to work!
 
 # Copy the result to the extensions directory:
-cp target/ext-mp-scenery-3.1.0.jar ~/.MusicPlayer/extensions
+cp target/ext-mp-scenery-4.0.0.jar ~/.MusicPlayer/extensions
 ```
 
 ## Requirements
 
-MusicPlayer 3.1 or higher.
+Compatible with any `4.x` release of MusicPlayer.
 
 ## License
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ca.corbett</groupId>
     <artifactId>ext-mp-scenery</artifactId>
-    <version>3.1.0</version>
+    <version>4.0.0</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>ca.corbett</groupId>
             <artifactId>musicplayer</artifactId>
-            <version>3.1</version>
+            <version>4.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/resources/ca/corbett/musicplayer/extensions/scenery/extInfo.json
+++ b/src/main/resources/ca/corbett/musicplayer/extensions/scenery/extInfo.json
@@ -1,9 +1,9 @@
 {
   "name": "Scenery",
   "author": "steve@corbett.ca",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "targetAppName": "MusicPlayer",
-  "targetAppVersion": "3.1",
+  "targetAppVersion": "4.0",
   "shortDescription": "Gently scrolling scenery",
   "longDescription": "Gently scrolling scenery with programmable companions to provide commentary."
 }


### PR DESCRIPTION
This PR addresses issue #9 by upgrading this extension to the latest `4.0` release of the parent application. Surprisingly, even though there were several breaking changes in this latest release, none of them affected this extension. So, this is just a straightforward version bump.